### PR TITLE
Add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include LICENSE
+include MANIFEST.in
+include README.rst
+include mopidy_soundcloud/ext.conf


### PR DESCRIPTION
This ensures that non-Python files like `mopidy_soundcloud/ext.conf` is included
in the source tarball uploaded to PyPI.
