### PR TITLE
Do not add spaces to search query

### DIFF
--- a/mopidy_soundcloud/library.py
+++ b/mopidy_soundcloud/library.py
@@ -132,7 +132,7 @@ class SoundCloudLibraryProvider(backend.LibraryProvider):
                     tracks=self.backend.remote.resolve_url(search_query)
                 )
         else:
-            search_query = ' '.join(query.values()[0])
+            search_query = ' '.join(query.values())
             logger.info('Searching SoundCloud for \'%s\'', search_query)
             return SearchResult(
                 uri='soundcloud:search',


### PR DESCRIPTION
Previously .join() was acting on a string instead of a list of search terms.
Now our search queries aren't getting mangled before getting passed to the
backend.

Signed-off-by: Tim Smart tim@fostle.com
