### PR TITLE
Do not add spaces to search query

### DIFF
--- a/mopidy_soundcloud/library.py
+++ b/mopidy_soundcloud/library.py
@@ -170,7 +170,7 @@ class SoundCloudLibraryProvider(backend.LibraryProvider):
                     tracks=self.backend.remote.resolve_url(search_query)
                 )
         else:
-            search_query = ''.join(query.values()[0])
+            search_query = query.values()[0]
             logger.info('Searching SoundCloud for \'%s\'', search_query)
             return SearchResult(
                 uri='soundcloud:search',


### PR DESCRIPTION
Additional whitespace causes irrelevant search results, as described in https://github.com/mopidy/mopidy-soundcloud/issues/27
