### PR TITLE
Fix issue 37

### DIFF
--- a/mopidy_soundcloud/soundcloud.py
+++ b/mopidy_soundcloud/soundcloud.py
@@ -178,7 +178,10 @@ class SoundCloudClient(object):
 
             track = data['track']
             if track:
-                likes.append(self.parse_track(track))
+                parsed_track = self.parse_track(track)
+
+                if parsed_track:
+                    likes.append(parse_track)
 
             pl = data['playlist']
             if pl:

--- a/mopidy_soundcloud/soundcloud.py
+++ b/mopidy_soundcloud/soundcloud.py
@@ -181,7 +181,7 @@ class SoundCloudClient(object):
                 parsed_track = self.parse_track(track)
 
                 if parsed_track:
-                    likes.append(parse_track)
+                    likes.append(parsed_track)
 
             pl = data['playlist']
             if pl:


### PR DESCRIPTION
Fix issues #37 and #43. The parse_track method in returns an empty array if the track is not streamable. Checks the parsed track before adding it to the likes.
