### PR TITLE
Handle ConnectionError before checking status_code

### DIFF
--- a/mopidy_soundcloud/soundcloud.py
+++ b/mopidy_soundcloud/soundcloud.py
@@ -76,6 +76,8 @@ class SoundCloudClient(object):
 
         try:
             self._get('me.json')
+        except requests.exceptions.ConnectionError as err:
+            logger.error('A Connection error occurred: %s', err)
         except Exception as err:
             if err.response.status_code == 401:
                 logger.error('Invalid "auth_token" used for SoundCloud '


### PR DESCRIPTION
In the event of a [ConnectionError](http://docs.python-requests.org/en/latest/api/#exceptions), when checking `err.response.status_code` an Uncaught Exception is thrown as the request object doesn't exist.

This occurs when the network is not fully ready. In my case this happens when running Mopidy as a daemon on startup (on a Raspberry Pi 2).

Example error:

    2015-04-25 18:56:51,341 ERROR [226:MainThread] mopidy.commands: Uncaught exception
    Traceback (most recent call last):
      File "/usr/lib/python2.7/dist-packages/mopidy/commands.py", line 274, in run
        backends = self.start_backends(config, backend_classes, audio)
      File "/usr/lib/python2.7/dist-packages/mopidy/commands.py", line 352, in start_backends
        config=config, audio=audio).proxy()
      File "/usr/lib/python2.7/dist-packages/pykka/actor.py", line 93, in start
        obj = cls(*args, **kwargs)
      File "/usr/share/mopidy/mopidy_soundcloud/actor.py", line 21, in __init__
        self.remote = SoundCloudClient(config['soundcloud'])
      File "/usr/share/mopidy/mopidy_soundcloud/soundcloud.py", line 80, in __init__
        if err.response.status_code == 401:
    AttributeError: 'NoneType' object has no attribute 'status_code'

By handling this exception first it prevents Mobidy from exiting prematurely.