### PR TITLE
fixes utf8 error in search

### DIFF
--- a/mopidy_soundcloud/soundcloud.py
+++ b/mopidy_soundcloud/soundcloud.py
@@ -209,7 +209,7 @@ class SoundCloudClient(object):
 
         search_results = self._get(
             'tracks.json?q=%s&filter=streamable&order=hotness&limit=%d' % (
-                quote_plus(query), self.explore_songs))
+                quote_plus(query.encode('utf8')), self.explore_songs))
         tracks = []
         for track in search_results:
             tracks.append(self.parse_track(track, False))


### PR DESCRIPTION
This allows a search like artist = Amon Düül

"params":{"artist":["Amon D\\u00fc\\u00fcl"],"uris":["soundcloud:"]}