### PR TITLE
Handle ConnectionError without a response

### DIFF
--- a/mopidy_soundcloud/soundcloud.py
+++ b/mopidy_soundcloud/soundcloud.py
@@ -77,7 +77,7 @@ class SoundCloudClient(object):
         try:
             self._get('me.json')
         except Exception as err:
-            if err.response.status_code == 401:
+            if err.response is not None and err.response.status_code == 401:
                 logger.error('Invalid "auth_token" used for SoundCloud '
                              'authentication!')
             else:


### PR DESCRIPTION
E.g.:

```
ConnectionError: HTTPSConnectionPool(host='api.soundcloud.com',
port=443): Max retries exceeded with url:
/me.json?client_id=XXX (Caused by
NewConnectionError('<requests.packages.urllib3.connection.VerifiedHTTPSConnection
object at 0x7f4356c37550>: Failed to establish a new connection: [Errno
-2] Name or service not known',))
```