### PR TITLE
Do not return tracks without uri in `lookup`

### DIFF
--- a/mopidy_soundcloud/library.py
+++ b/mopidy_soundcloud/library.py
@@ -200,10 +200,13 @@ class SoundCloudLibraryProvider(backend.LibraryProvider):
         if 'sc:' in uri:
             uri = uri.replace('sc:', '')
             return self.backend.remote.resolve_url(uri)
-        else:
-            try:
-                track_id = self.backend.remote.parse_track_uri(uri)
-                return [self.backend.remote.get_track(track_id)]
-            except Exception as error:
-                logger.error('Failed to lookup %s: %s', uri, error)
-                return []
+
+        try:
+            track_id = self.backend.remote.parse_track_uri(uri)
+            track = self.backend.remote.get_track(track_id)
+            if track.uri:
+                return [track]
+            logger.debug('lookup: no track found for id %s' % (track_id,))
+        except Exception as error:
+            logger.error('Failed to lookup %s: %s', uri, error)
+        return []


### PR DESCRIPTION
When these are served e.g. through "lsinfo SoundCloud/Played" to
ncmpcpp, it might crash: http://bugs.musicpd.org/view.php?id=4468.

Ref: https://github.com/mopidy/mopidy/issues/1340