### PR TITLE
#48 stream shows a configurable amount of tracks and playlists now

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,7 @@ Configuration
     [soundcloud]
     auth_token = 1-1111-1111111
     explore_songs = 25
+    stream_entries = 100
 
 
 Project resources

--- a/mopidy_soundcloud/__init__.py
+++ b/mopidy_soundcloud/__init__.py
@@ -25,6 +25,7 @@ class SoundCloudExtension(ext.Extension):
         schema['auth_token'] = config.Secret()
         schema['explore'] = config.Deprecated()
         schema['explore_pages'] = config.Deprecated()
+        schema['stream_entries'] = config.Integer()
         return schema
 
     def validate_config(self, config):  # no_coverage

--- a/mopidy_soundcloud/ext.conf
+++ b/mopidy_soundcloud/ext.conf
@@ -6,3 +6,6 @@ auth_token =
 
 # Number of songs to fetch in explore section
 explore_songs = 25
+
+# Number of tracks and playlists to fetch from user stream
+stream_entries = 100

--- a/mopidy_soundcloud/library.py
+++ b/mopidy_soundcloud/library.py
@@ -88,7 +88,8 @@ class SoundCloudLibraryProvider(backend.LibraryProvider):
             try:
                 name, set_id = data
             except (TypeError, ValueError):
-                logger.debug('Adding track "%s" from stream to vfs' % data.name)
+                logger.debug(
+                    'Adding track "%s" from stream to vfs' % data.name)
                 vfs_list[data.name] = models.Ref.track(
                     uri=data.uri, name=data.name
                 )

--- a/mopidy_soundcloud/soundcloud.py
+++ b/mopidy_soundcloud/soundcloud.py
@@ -114,9 +114,8 @@ class SoundCloudClient(object):
     def get_explore(self, query_explore_id=None):
         explore = self.get_explore_categories()
         if query_explore_id:
-            url = \
-                'explore/{urn}?limit={limit}&offset=0&linked_partitioning=1' \
-                    .format(
+            url = 'explore/{urn}?limit={limit}&offset=0&linked_partitioning=1'\
+                .format(
                     urn=explore[int(query_explore_id)],
                     limit=self.explore_songs
                 )

--- a/mopidy_soundcloud/soundcloud.py
+++ b/mopidy_soundcloud/soundcloud.py
@@ -8,8 +8,9 @@ import unicodedata
 from multiprocessing.pool import ThreadPool
 from urllib import quote_plus
 
-import requests
 from mopidy.models import Album, Artist, Track
+
+import requests
 
 logger = logging.getLogger(__name__)
 

--- a/mopidy_soundcloud/soundcloud.py
+++ b/mopidy_soundcloud/soundcloud.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 
-import collections
 import logging
 import re
 import string
@@ -9,10 +8,8 @@ import unicodedata
 from multiprocessing.pool import ThreadPool
 from urllib import quote_plus
 
-from mopidy.models import Album, Artist, Track
-
 import requests
-
+from mopidy.models import Album, Artist, Track
 
 logger = logging.getLogger(__name__)
 
@@ -91,19 +88,22 @@ class SoundCloudClient(object):
 
     @cache()
     def get_user_stream(self):
-        # User timeline like playlist which uses undocumented api
+        # User timeline like playlist which uses undocumented api:
         # https://api.soundcloud.com/e1/me/stream.json?limit=0
-        # additional parameters are 'promoted_playlist=true' or 'offset=00000152-cc97-84a0-0000-00002a293ab5'
+        # Additional parameters are: 'promoted_playlist=true'
+        # or 'offset=00000152-cc97-84a0-0000-00002a293ab5'
         tracks_and_playlists = []
         stream = self._get('e1/me/stream.json?limit=%s' % self.stream_entries)
         for data in stream.get('collection'):
             kind = data.get('type')
             # multiple types of track with same data
             if 'track' in kind:
-                tracks_and_playlists.append(self.parse_track(data.get('track')))
+                tracks_and_playlists.append(
+                    self.parse_track(data.get('track')))
             if 'playlist' in kind:
                 playlist = data.get('playlist')
-                tracks_and_playlists.append((playlist.get('title'), str(playlist.get('id'))))
+                tracks_and_playlists.append(
+                    (playlist.get('title'), str(playlist.get('id'))))
 
         return self.sanitize_tracks(tracks_and_playlists)
 
@@ -114,8 +114,9 @@ class SoundCloudClient(object):
     def get_explore(self, query_explore_id=None):
         explore = self.get_explore_categories()
         if query_explore_id:
-            url = 'explore/{urn}?limit={limit}&offset=0&linked_partitioning=1'\
-                .format(
+            url = \
+                'explore/{urn}?limit={limit}&offset=0&linked_partitioning=1' \
+                    .format(
                     urn=explore[int(query_explore_id)],
                     limit=self.explore_songs
                 )

--- a/tests/fixtures/sc-stream.yaml
+++ b/tests/fixtures/sc-stream.yaml
@@ -6,38 +6,9 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Authorization: [!!python/unicode 'OAuth 1-35204-61921957-55796ebef403996']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.4.3 CPython/2.7.8 Linux/3.16.0-28-generic]
+      User-Agent: [python-requests/2.9.1]
     method: GET
-    uri: https://api.soundcloud.com:443/e1/me/stream.json?offset=0e1/me/stream.json?offset=0e1/me/stream.json?offset=0e1/me/stream.json?offset=0e1/me/stream.json?offset=0&client_id=93e33e327fd8a9b77becd179652272e2
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAATBwQqAIAwA0H/ZOVxehehDIkJsoqFOdDtF/957L0QVHXSlQREcJJE+HaLv2UzW
-        dofCepvAFcliJZwyyFfzTG57yTXLZldYIHApFCRzA3ec3w8AAP//AwCP9XBDVwAAAA==
-    headers:
-      access-control-allow-headers: ['Accept, Authorization, Content-Type, Origin']
-      access-control-allow-methods: ['GET, PUT, POST, DELETE']
-      access-control-allow-origin: ['*']
-      access-control-expose-headers: [Date]
-      cache-control: ['private, max-age=0']
-      content-encoding: [gzip]
-      content-length: ['106']
-      content-type: [application/json]
-      date: ['Fri, 02 Jan 2015 17:03:54 GMT']
-      server: [am/2]
-      set-cookie: [_session_auth_key="iuo9QNN6oaPVa3gj9XyKTHZtsxE="]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [!!python/unicode 'OAuth 1-35204-61921957-55796ebef403996']
-      Connection: [keep-alive]
-      Cookie: [_session_auth_key="iuo9QNN6oaPVa3gj9XyKTHZtsxE="]
-      User-Agent: [python-requests/2.4.3 CPython/2.7.8 Linux/3.16.0-28-generic]
-    method: GET
-    uri: https://api.soundcloud.com:443/e1/me/stream.json?offset=1e1/me/stream.json?offset=1e1/me/stream.json?offset=1e1/me/stream.json?offset=1e1/me/stream.json?offset=1&client_id=93e33e327fd8a9b77becd179652272e2
+    uri: https://api.soundcloud.com/e1/me/stream.json?limit=10&client_id=93e33e327fd8a9b77becd179652272e2
   response:
     body:
       string: !!binary |
@@ -52,7 +23,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['106']
       content-type: [application/json]
-      date: ['Fri, 02 Jan 2015 17:03:54 GMT']
+      date: ['Sat, 20 Feb 2016 19:14:11 GMT']
       server: [am/2]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,6 +18,7 @@ class ApiTest(unittest.TestCase):
         config = SoundCloudExtension().get_config_schema()
         config['auth_token'] = '1-35204-61921957-55796ebef403996'
         config['explore_songs'] = 10
+        config['stream_entries'] = 10
         # using this user http://maildrop.cc/inbox/mopidytestuser
         self.api = SoundCloudClient(config)
 
@@ -75,8 +76,8 @@ class ApiTest(unittest.TestCase):
 
     @vcr.use_cassette('tests/fixtures/sc-stream.yaml')
     def test_get_user_stream(self):
-        tracks = self.api.get_user_stream()
-        self.assertIsInstance(tracks, list)
+        tracks_and_playlists = self.api.get_user_stream()
+        self.assertIsInstance(tracks_and_playlists, list)
 
     @vcr.use_cassette('tests/fixtures/sc-explore.yaml')
     def test_get_explore(self):

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -22,3 +22,4 @@ class ExtensionTest(unittest.TestCase):
 
         self.assertIn('auth_token', schema)
         self.assertIn('explore_songs', schema)
+        self.assertIn('stream_entries', schema)


### PR DESCRIPTION
This fixes issue #48 and includes playlists as separate directories. The tracks of the playlists won't be prefetched and the number of tracks/playlists is configurable now.
