### PR TITLE
Don't transform folder names via safe_url(), fixing #64 and #103

### DIFF
--- a/mopidy_soundcloud/library.py
+++ b/mopidy_soundcloud/library.py
@@ -5,7 +5,6 @@ import urllib.parse
 
 from mopidy import backend, models
 from mopidy.models import SearchResult, Track
-from mopidy_soundcloud.soundcloud import safe_url
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +14,7 @@ def generate_uri(path):
 
 
 def new_folder(name, path):
-    return models.Ref.directory(uri=generate_uri(path), name=safe_url(name))
+    return models.Ref.directory(uri=generate_uri(path), name=name)
 
 
 def simplify_search_query(query):


### PR DESCRIPTION
Folder names can simply be Unicode. This means the user won't see
URL encoding like + for space and % encoding. Also, the original
Unicode characters will remain. Even forward slashes are ok.