### PR TITLE
Ignore flake8 B019. Doesn't apply as we have a single class instance.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -76,6 +76,8 @@ select =
     # pep8-naming rules
     N
 ignore =
+    # B019: Use of `functools.lru_cache` on methods can lead to memory leaks.
+    B019
     # E203: whitespace before ':' (not PEP8 compliant)
     E203
     # E501: line too long (replaced by B950)


### PR DESCRIPTION
Ignore "B019 Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks. The cache may retain instance references, preventing garbage collection." which doesn't apply to our singleton class.