### PR TITLE
Fix/workaround auth changes

### DIFF
--- a/mopidy_soundcloud/soundcloud.py
+++ b/mopidy_soundcloud/soundcloud.py
@@ -148,8 +148,6 @@ class ThrottlingHttpAdapter(HTTPAdapter):
 
 
 class SoundCloudClient:
-    CLIENT_ID = "93e33e327fd8a9b77becd179652272e2"
-
     public_client_id = None
 
     def __init__(self, config):
@@ -280,7 +278,7 @@ class SoundCloudClient:
 
     def _get(self, url, limit=None):
         url = f"https://api.soundcloud.com/{url}"
-        params = [("client_id", self.CLIENT_ID)]
+        params = []
         if limit:
             params.insert(0, ("limit", self.explore_songs))
         try:
@@ -424,7 +422,7 @@ class SoundCloudClient:
                     )
 
         # ~quickly yields rate limit errors
-        req = self.http_client.head(f"{stream_url}?client_id={self.CLIENT_ID}")
+        req = self.http_client.head(stream_url)
         if req.status_code == 302:
             return req.headers.get("Location", None)
         elif req.status_code == 429:

--- a/mopidy_soundcloud/soundcloud.py
+++ b/mopidy_soundcloud/soundcloud.py
@@ -410,7 +410,7 @@ class SoundCloudClient:
                     stream = self._get_public_stream(progressive_urls["stream"])
 
                 try:
-                    return stream.json().get("url")
+                    return stream.json()["url"]
                 except Exception as e:
                     logger.info(
                         "Streaming of public song using public client id failed, "


### PR DESCRIPTION
If we remove the client id request parameter things seem to start working again. The SC docs claim the OAuth token will expire after an hour but that does not seem to be the case.

Also fixed where the non-public client id method to obtain a stream link was never being called. Although weirdly this method isn't using our client id anymore and still seems to work... I'm not interesting enough in using SC to get into this much further.