### PR TITLE
Fix for "Failed to update SoundCloud public client id", and then playing only 30 seconds of tracks

### DIFF
--- a/src/mopidy_soundcloud/soundcloud.py
+++ b/src/mopidy_soundcloud/soundcloud.py
@@ -333,7 +333,7 @@ class SoundCloudClient:
             return self.public_stream_client.get(url).content.decode("utf-8")
 
         public_page = get_page("https://soundcloud.com/")
-        regex_str = r"client_id=([a-zA-Z0-9]{16,})"
+        regex_str = r'client_id:"([a-zA-Z0-9]{16,})"'
         soundcloud_soup = BeautifulSoup(public_page, "html.parser")
         scripts = soundcloud_soup.find_all("script", attrs={"src": True})
         self.public_client_id = None


### PR DESCRIPTION
Whenever I played something, it stopped after 30 seconds. I thought that is related to the following error:
`WARNING  [SoundCloudBackend-5 (_actor_loop)] mopidy_soundcloud.soundcloud Failed to update SoundCloud public client id`

Searching for `client_id` using Firefox developer tools, I found it in the `client_id:"..."` format. Changing the regular expression to use this format made the error go away and allowed me to play a track beyond 30 seconds.

This was tested in Mopidy 3.4.2-1ubuntu0.1.